### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Bug report about the Safe smart contracts
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,6 +1,6 @@
 ---
 name: Custom issue template
-about: Describe this issue template's purpose here.
+about: File a custom issue if none of the other templates apply.
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea or feature request for the Safe smart contracts project
+title: ''
+labels: ''
+assignees: ''
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub issue templates to standardize metadata and add a generic custom template.

Documentation:
- Add default title, labels, and assignees fields to existing bug report and feature request issue templates.
- Introduce a new generic custom issue template for issues that don't fit existing categories.