### PR TITLE
Do Not Propagate Reverts on Signatures (#1115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This changelog only contains changes starting from version 1.3.0
 
 ## Changes
 
-None.
+### General
+
+#### Do not propagate contract signature validation reverts
+
+Previously, a reverting `isValidSignature` call during contract signature validation in `checkNSignatures` would bubble up the revert to the caller. This allowed an attacker-controlled `owner` address to supply arbitrary revert data. The `checkNSignatures` call now reverts with a `GS024` error in case of a revert (the same error for an invalid signature).
+
+**Breaking change**: The return data from `isValidSignature` is now checked strictly. Previously, Solidity's ABI decoder would accept responses with dirty lower bits and additional trailing bytes. The new low-level call requires exactly 32 bytes of return data whose first 4 bytes equal `EIP1271_MAGIC_VALUE` (`0x1626ba7e`) with the remaining 28 bytes zero-padded.
 
 # Version 1.5.0
 

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -7,13 +7,13 @@ import {ModuleManager} from "./base/ModuleManager.sol";
 import {OwnerManager} from "./base/OwnerManager.sol";
 import {EIP7951} from "./common/EIP7951.sol";
 import {NativeCurrencyPaymentFallback} from "./common/NativeCurrencyPaymentFallback.sol";
+import {SecuredSignatureValidator} from "./common/SecuredSignatureValidator.sol";
 import {SecuredTokenTransfer} from "./common/SecuredTokenTransfer.sol";
 import {SignatureDecoder} from "./common/SignatureDecoder.sol";
 import {Singleton} from "./common/Singleton.sol";
 import {StorageAccessible} from "./common/StorageAccessible.sol";
 import {SafeMath} from "./external/SafeMath.sol";
 import {ISafe} from "./interfaces/ISafe.sol";
-import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/ISignatureValidator.sol";
 import {Enum} from "./interfaces/Enum.sol";
 
 /**
@@ -44,7 +44,7 @@ contract Safe is
     OwnerManager,
     SignatureDecoder,
     SecuredTokenTransfer,
-    ISignatureValidatorConstants,
+    SecuredSignatureValidator,
     FallbackManager,
     StorageAccessible,
     EIP7951,
@@ -292,7 +292,7 @@ contract Safe is
         }
         /* solhint-enable no-inline-assembly */
 
-        if (ISignatureValidator(owner).isValidSignature(dataHash, contractSignature) != EIP1271_MAGIC_VALUE) revertWithError("GS024");
+        if (!validateContractSignature(owner, dataHash, contractSignature)) revertWithError("GS024");
     }
 
     /**

--- a/contracts/common/SecuredSignatureValidator.sol
+++ b/contracts/common/SecuredSignatureValidator.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+import {ISignatureValidator, ISignatureValidatorConstants} from "../interfaces/ISignatureValidator.sol";
+
+/**
+ * @title Secured Signature Validator
+ * @notice Safely validates ERC-1271 contract signatures without propagating reverts.
+ */
+abstract contract SecuredSignatureValidator is ISignatureValidatorConstants {
+    /**
+     * @notice Validates an ERC-1271 contract signature, returning `true` if valid and `false` otherwise.
+     * @dev This method never reverts. A reverting `isValidSignature` call is treated as an invalid
+     *      signature. Exactly 32 bytes must be returned equal to ABI-encoded {EIP1271_MAGIC_VALUE}.
+     * @param owner The contract whose `isValidSignature` method is called.
+     * @param dataHash The hash of the data that was signed.
+     * @param signature The signature bytes passed to `isValidSignature`.
+     * @return valid `true` if the signature is valid, `false` otherwise.
+     */
+    function validateContractSignature(address owner, bytes32 dataHash, bytes memory signature) internal view returns (bool valid) {
+        bytes memory data = abi.encodeWithSelector(ISignatureValidator.isValidSignature.selector, dataHash, signature);
+        (bool success, bytes memory result) = owner.staticcall(data);
+        return success && result.length == 32 && abi.decode(result, (bytes32)) == bytes32(EIP1271_MAGIC_VALUE);
+    }
+}

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -20,6 +20,7 @@ import {
     buildSignatureBytes,
 } from "../../src/utils/execution";
 import { chainId } from "../utils/encoding";
+import { revertingSignatureValidatorContract } from "../utils/contracts";
 
 describe("Safe", () => {
     const setupTests = hre.deployments.createFixture(async ({ deployments }) => {
@@ -510,7 +511,9 @@ describe("Safe", () => {
             } as const;
             const signatures = buildSignatureBytes([selfSignature]);
 
-            await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS025");
+            // The inner `isValidSignature` call reverts with GS025, but the parent Safe signature verification logic
+            // uses GS024 error codes for contract signature errors.
+            await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS024");
         });
 
         it("should allow for EIP-7702 delegated Safes to sign for themselves [@skip-on-coverage]", async () => {
@@ -1094,6 +1097,51 @@ describe("Safe", () => {
             const safeConnectUser2 = safe.connect(user2);
 
             await safeConnectUser2["checkNSignatures(address,bytes32,bytes,uint256)"](user1.address, txHash, signatures, 1);
+        });
+
+        it("should revert with GS024 if a contract owner's isValidSignature reverts", async () => {
+            const {
+                signers: [user1],
+            } = await setupTests();
+
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            const safe = await getSafe({ owners: [revertingValidatorAddress], threshold: 1 });
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(safe["checkNSignatures(address,bytes32,bytes,uint256)"](AddressZero, txHash, signatures, 1)).to.be.revertedWith(
+                "GS024",
+            );
+        });
+
+        it("should revert with GS024 if a non-owner contract's isValidSignature reverts", async () => {
+            const {
+                signers: [user1, user2],
+            } = await setupTests();
+
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // user2 is the only owner, the reverting contract is NOT an owner.
+            const safe = await getSafe({ owners: [user2.address], threshold: 1 });
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            // validateContractSignature is called before the owner-membership check (GS026), so the
+            // revert is caught and surfaced as GS024 rather than bubbling up to the caller.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(safe["checkNSignatures(address,bytes32,bytes,uint256)"](AddressZero, txHash, signatures, 1)).to.be.revertedWith(
+                "GS024",
+            );
         });
     });
 

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -11,7 +11,7 @@ import {
     signHash,
 } from "../../src/utils/execution";
 import { chainId } from "../utils/encoding";
-import { badSimulatorContract, killLibContract } from "../utils/contracts";
+import { badSimulatorContract, killLibContract, revertingSignatureValidatorContract } from "../utils/contracts";
 
 describe("CompatibilityFallbackHandler", () => {
     const setupTests = hre.deployments.createFixture(async ({ deployments }) => {
@@ -227,6 +227,57 @@ describe("CompatibilityFallbackHandler", () => {
 
             const signatures = buildSignatureBytes([user1Signature, user2Signature]);
             await expect(validator.connect(user1).isValidSignature.staticCall(dataHash, signatures)).to.be.reverted;
+        });
+
+        it("should revert with GS024 if a contract owner's isValidSignature reverts", async () => {
+            const {
+                handler,
+                signers: [user1],
+            } = await setupTests();
+            const handlerAddress = await handler.getAddress();
+            const dataHash = ethers.keccak256("0xbaddad");
+
+            // Deploy a contract whose isValidSignature always reverts.
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // Create a Safe where the reverting contract is the sole owner.
+            const testSafe = await getSafe({ owners: [revertingValidatorAddress], threshold: 1, fallbackHandler: handlerAddress });
+            const testSafeAddress = await testSafe.getAddress();
+            const testValidator = await getCompatFallbackHandler(testSafeAddress);
+
+            // Build a contract signature pointing to the reverting owner.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            // The revert from isValidSignature is caught by validateContractSignature and surfaced as GS024.
+            await expect(testValidator.isValidSignature.staticCall(dataHash, signatures)).to.be.revertedWith("GS024");
+        });
+
+        it("should revert with GS024 if a non-owner contract's isValidSignature reverts", async () => {
+            const {
+                handler,
+                signers: [user1],
+            } = await setupTests();
+            const handlerAddress = await handler.getAddress();
+            const dataHash = ethers.keccak256("0xbaddad");
+
+            // Deploy a contract whose isValidSignature always reverts.
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // Create a Safe where user1 is the only owner, the reverting contract is NOT an owner.
+            const testSafe = await getSafe({ owners: [user1.address], threshold: 1, fallbackHandler: handlerAddress });
+            const testSafeAddress = await testSafe.getAddress();
+            const testValidator = await getCompatFallbackHandler(testSafeAddress);
+
+            // Build a contract signature pointing to the reverting non-owner.
+            // validateContractSignature is called before the owner-membership check (GS026), so the
+            // revert is caught and surfaced as GS024 rather than bubbling up to the caller.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(testValidator.isValidSignature.staticCall(dataHash, signatures)).to.be.revertedWith("GS024");
         });
     });
 

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -83,6 +83,17 @@ export const badSimulatorContract = async (deployer: Signer) => {
     return deployContractFromSource(deployer, badSimulatorSource);
 };
 
+export const revertingSignatureValidatorSource = `
+contract Test {
+    function isValidSignature(bytes32, bytes memory) external pure returns (bytes4) {
+        revert("isValidSignature reverted");
+    }
+}`;
+
+export const revertingSignatureValidatorContract = async (deployer: Signer) => {
+    return deployContractFromSource(deployer, revertingSignatureValidatorSource);
+};
+
 /**
  * Retrieves the sender address from the contract runner.
  * It is useful when using methods like `hre.ethers.getContractAt` which automatically attach


### PR DESCRIPTION
This PR changes the behaviour of `checkNSignatures` to not propagate reverts of `isValidSignature` calls. This is done because `signatures` bytes are not trusted input, and allows an attacker to cause the Safe to revert with attacker-controlled data. This ensures consistent use of error codes across the signature validation logic in the core Safe account.

New tests were added to check the implementation. A changelog entry was also added, as this change introduces breaking behaviour around the signature format (specifically dirty lower bytes and extra data appended to the `isValidSignature` return data).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License
Agreement](https://docs.safefoundation.org/cla).

---------


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

## Summary by Sourcery

Ensure Safe contract and fallback handler treat reverting ERC-1271 contract signature checks as invalid signatures with a consistent GS024 error code.

Bug Fixes:
- Prevent attacker-controlled revert data from bubbling up from isValidSignature during contract signature validation by treating reverts as GS024 invalid signatures.

Enhancements:
- Introduce a SecuredSignatureValidator utility to perform ERC-1271 signature validation via low-level calls without propagating reverts and with strict return-data checks.
- Adopt SecuredSignatureValidator in the Safe core contract for contract owner signature verification to unify error handling.

Documentation:
- Document the new contract signature validation behavior and strict EIP-1271 return-data requirements in the changelog, including the breaking nature of the change.

Tests:
- Add Safe core and CompatibilityFallbackHandler tests covering reverting isValidSignature implementations for both owner and non-owner contracts and asserting GS024 reverts.

Chores:
- Add a reusable revertingSignatureValidator test contract helper for ERC-1271 revert behavior testing.