### PR TITLE
Do Not Propagate Reverts on Signatures (safe-fndn#1115) 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@
 
 ## CLA signature
 
-With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
+With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This changelog only contains changes starting from version 1.3.0
 
 ## Changes
 
-None.
+### General
+
+#### Do not propagate contract signature validation reverts
+
+Previously, a reverting `isValidSignature` call during contract signature validation in `checkNSignatures` would bubble up the revert to the caller. This allowed an attacker-controlled `owner` address to supply arbitrary revert data. The `checkNSignatures` call now reverts with a `GS024` error in case of a revert (the same error for an invalid signature).
+
+**Breaking change**: The return data from `isValidSignature` is now checked strictly. Previously, Solidity's ABI decoder would accept responses with dirty lower bits and additional trailing bytes. The new low-level call requires exactly 32 bytes of return data whose first 4 bytes equal `EIP1271_MAGIC_VALUE` (`0x1626ba7e`) with the remaining 28 bytes zero-padded.
 
 # Version 1.5.0
 

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -7,13 +7,13 @@ import {ModuleManager} from "./base/ModuleManager.sol";
 import {OwnerManager} from "./base/OwnerManager.sol";
 import {EIP7951} from "./common/EIP7951.sol";
 import {NativeCurrencyPaymentFallback} from "./common/NativeCurrencyPaymentFallback.sol";
+import {SecuredSignatureValidator} from "./common/SecuredSignatureValidator.sol";
 import {SecuredTokenTransfer} from "./common/SecuredTokenTransfer.sol";
 import {SignatureDecoder} from "./common/SignatureDecoder.sol";
 import {Singleton} from "./common/Singleton.sol";
 import {StorageAccessible} from "./common/StorageAccessible.sol";
 import {SafeMath} from "./external/SafeMath.sol";
 import {ISafe} from "./interfaces/ISafe.sol";
-import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/ISignatureValidator.sol";
 import {Enum} from "./interfaces/Enum.sol";
 
 /**
@@ -44,7 +44,7 @@ contract Safe is
     OwnerManager,
     SignatureDecoder,
     SecuredTokenTransfer,
-    ISignatureValidatorConstants,
+    SecuredSignatureValidator,
     FallbackManager,
     StorageAccessible,
     EIP7951,
@@ -292,7 +292,7 @@ contract Safe is
         }
         /* solhint-enable no-inline-assembly */
 
-        if (ISignatureValidator(owner).isValidSignature(dataHash, contractSignature) != EIP1271_MAGIC_VALUE) revertWithError("GS024");
+        if (!validateContractSignature(owner, dataHash, contractSignature)) revertWithError("GS024");
     }
 
     /**

--- a/contracts/common/SecuredSignatureValidator.sol
+++ b/contracts/common/SecuredSignatureValidator.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+import {ISignatureValidator, ISignatureValidatorConstants} from "../interfaces/ISignatureValidator.sol";
+
+/**
+ * @title Secured Signature Validator
+ * @notice Safely validates ERC-1271 contract signatures without propagating reverts.
+ */
+abstract contract SecuredSignatureValidator is ISignatureValidatorConstants {
+    /**
+     * @notice Validates an ERC-1271 contract signature, returning `true` if valid and `false` otherwise.
+     * @dev This method never reverts. A reverting `isValidSignature` call is treated as an invalid
+     *      signature. Exactly 32 bytes must be returned equal to ABI-encoded {EIP1271_MAGIC_VALUE}.
+     * @param owner The contract whose `isValidSignature` method is called.
+     * @param dataHash The hash of the data that was signed.
+     * @param signature The signature bytes passed to `isValidSignature`.
+     * @return valid `true` if the signature is valid, `false` otherwise.
+     */
+    function validateContractSignature(address owner, bytes32 dataHash, bytes memory signature) internal view returns (bool valid) {
+        bytes memory data = abi.encodeWithSelector(ISignatureValidator.isValidSignature.selector, dataHash, signature);
+        (bool success, bytes memory result) = owner.staticcall(data);
+        return success && result.length == 32 && abi.decode(result, (bytes32)) == bytes32(EIP1271_MAGIC_VALUE);
+    }
+}

--- a/contracts/handler/TokenCallbackHandler.sol
+++ b/contracts/handler/TokenCallbackHandler.sol
@@ -46,9 +46,9 @@ contract TokenCallbackHandler is HandlerContext, ERC1155TokenReceiver, ERC777Tok
     /**
      * @inheritdoc ERC777TokensRecipient
      * @dev Account that wishes to receive the tokens also needs to register the implementer (this contract) via the ERC-1820 interface registry.
-     *      From the standard: "This is done by calling the setInterfaceImplementer function on the ERC-1820 registry with the holder address as
-     *      the address, the keccak256 hash of ERC777TokensSender (0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895) as the
-     *      interface hash, and the address of the contract implementing the ERC777TokensSender as the implementer."
+     *      From the standard: "This is done by calling the setInterfaceImplementer function on the ERC-1820 registry with the recipient address as
+     *      the address, the keccak256 hash of ERC777TokensRecipient (0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b) as the
+     *      interface hash, and the address of the contract implementing the ERC777TokensRecipient as the implementer."
      */
     function tokensReceived(address, address, address, uint256, bytes calldata, bytes calldata) external pure override {
         // We implement this for completeness, doesn't really have any value

--- a/contracts/interfaces/IFallbackManager.sol
+++ b/contracts/interfaces/IFallbackManager.sol
@@ -28,10 +28,21 @@ interface IFallbackManager {
     /**
      * @notice Forwards all calls to the fallback handler if set.
      *         Returns empty data if no handler is set.
-     * @dev Appends the non-padded caller address to the calldata to be optionally used in the handler
-     *      The handler can make use of {HandlerContext} to extract the address.
-     *      This is done because in the next call frame the `msg.sender` will be {FallbackManager}'s address
-     *      and having the original caller address may enable additional verification scenarios.
+     * @dev The call to the handler is made via the `CALL` opcode (not `DELEGATECALL`), so:
+     *      - In the handler's call frame, `msg.sender` is the Safe's own address, not the original external caller.
+     *      - The handler executes in its own storage context; it cannot read or write Safe storage directly.
+     *      - `CALL` is used intentionally to limit the attack surface: `DELEGATECALL` would execute handler code
+     *        in the Safe's storage context, giving the handler unrestricted write access to all Safe state.
+     *
+     *      ⚠️ IMPORTANT SECURITY NOTE: Because `msg.sender` equals the Safe address inside the handler, the
+     *      handler can take actions on behalf of the Safe in other contracts. For example, if the fallback
+     *      handler is set to a token contract, any external caller can trigger token operations
+     *      (e.g. `transfer`, `approve`) on behalf of the Safe. Only set trusted, purpose-built contracts as
+     *      fallback handlers and verify they do not expose state-changing functions that rely solely on
+     *      `msg.sender` for authorisation.
+     *
+     *      The original caller address is appended (non-padded) to the calldata before forwarding.
+     *      The handler can use {HandlerContext._msgSender()} to recover it. This pattern is based on ERC-2771.
      */
     fallback() external;
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -141,3 +141,17 @@ If the refund parameter is set to true, the Safe will refund the gas costs to th
 #### Fallback contract
 
 A Fallback contract contains logic outside of the scope of the core Safe Smart Account, such as the token callback logic and/or logic that didn't fit into the core contracts because of bytecode size limitations.
+
+**How call forwarding works**
+
+When an unknown function selector (or empty calldata) is received by the Safe, the `FallbackManager` forwards the call to the configured fallback handler via the `CALL` opcode. The original caller's address is appended (non-padded) as the last 20 bytes of calldata before forwarding; fallback handlers that extend `HandlerContext` can recover this address via `_msgSender()` (following the [ERC-2771](https://eips.ethereum.org/EIPS/eip-2771) convention).
+
+**Why `CALL` instead of `DELEGATECALL`**
+
+`CALL` means the handler executes in its own storage context — it cannot read or write Safe storage directly. `DELEGATECALL` would run the handler's code inside the Safe's storage context, giving it unrestricted write access to every Safe state variable (owners, threshold, modules, guards). Using `CALL` is therefore a deliberate security boundary that isolates handler logic from core Safe state. Modules already support `DELEGATECALL` for cases where extending Safe storage is intentional and has been explicitly authorised by the owners.
+
+**Security implications of `msg.sender` rewriting**
+
+Inside the handler's call frame, `msg.sender` is the Safe's own address — not the original external caller. This has an important consequence: if the fallback handler is set to a contract that uses `msg.sender` for authorisation (e.g. an ERC-20 token), any external account can trigger operations on behalf of the Safe through the fallback path.
+
+> ⚠️ WARNING: Only set purpose-built, audited contracts as fallback handlers. Verify that the handler does not expose state-changing entry points that authorise callers solely based on `msg.sender` A malicious or carelessly written fallback handler can drain Safe assets or manipulate Safe-held positions in DeFi protocols.

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -20,6 +20,7 @@ import {
     buildSignatureBytes,
 } from "../../src/utils/execution";
 import { chainId } from "../utils/encoding";
+import { revertingSignatureValidatorContract } from "../utils/contracts";
 
 describe("Safe", () => {
     const setupTests = hre.deployments.createFixture(async ({ deployments }) => {
@@ -510,7 +511,9 @@ describe("Safe", () => {
             } as const;
             const signatures = buildSignatureBytes([selfSignature]);
 
-            await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS025");
+            // The inner `isValidSignature` call reverts with GS025, but the parent Safe signature verification logic
+            // uses GS024 error codes for contract signature errors.
+            await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS024");
         });
 
         it("should allow for EIP-7702 delegated Safes to sign for themselves [@skip-on-coverage]", async () => {
@@ -1094,6 +1097,51 @@ describe("Safe", () => {
             const safeConnectUser2 = safe.connect(user2);
 
             await safeConnectUser2["checkNSignatures(address,bytes32,bytes,uint256)"](user1.address, txHash, signatures, 1);
+        });
+
+        it("should revert with GS024 if a contract owner's isValidSignature reverts", async () => {
+            const {
+                signers: [user1],
+            } = await setupTests();
+
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            const safe = await getSafe({ owners: [revertingValidatorAddress], threshold: 1 });
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(safe["checkNSignatures(address,bytes32,bytes,uint256)"](AddressZero, txHash, signatures, 1)).to.be.revertedWith(
+                "GS024",
+            );
+        });
+
+        it("should revert with GS024 if a non-owner contract's isValidSignature reverts", async () => {
+            const {
+                signers: [user1, user2],
+            } = await setupTests();
+
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // user2 is the only owner, the reverting contract is NOT an owner.
+            const safe = await getSafe({ owners: [user2.address], threshold: 1 });
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            // validateContractSignature is called before the owner-membership check (GS026), so the
+            // revert is caught and surfaced as GS024 rather than bubbling up to the caller.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(safe["checkNSignatures(address,bytes32,bytes,uint256)"](AddressZero, txHash, signatures, 1)).to.be.revertedWith(
+                "GS024",
+            );
         });
     });
 

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -11,7 +11,7 @@ import {
     signHash,
 } from "../../src/utils/execution";
 import { chainId } from "../utils/encoding";
-import { badSimulatorContract, killLibContract } from "../utils/contracts";
+import { badSimulatorContract, killLibContract, revertingSignatureValidatorContract } from "../utils/contracts";
 
 describe("CompatibilityFallbackHandler", () => {
     const setupTests = hre.deployments.createFixture(async ({ deployments }) => {
@@ -227,6 +227,57 @@ describe("CompatibilityFallbackHandler", () => {
 
             const signatures = buildSignatureBytes([user1Signature, user2Signature]);
             await expect(validator.connect(user1).isValidSignature.staticCall(dataHash, signatures)).to.be.reverted;
+        });
+
+        it("should revert with GS024 if a contract owner's isValidSignature reverts", async () => {
+            const {
+                handler,
+                signers: [user1],
+            } = await setupTests();
+            const handlerAddress = await handler.getAddress();
+            const dataHash = ethers.keccak256("0xbaddad");
+
+            // Deploy a contract whose isValidSignature always reverts.
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // Create a Safe where the reverting contract is the sole owner.
+            const testSafe = await getSafe({ owners: [revertingValidatorAddress], threshold: 1, fallbackHandler: handlerAddress });
+            const testSafeAddress = await testSafe.getAddress();
+            const testValidator = await getCompatFallbackHandler(testSafeAddress);
+
+            // Build a contract signature pointing to the reverting owner.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            // The revert from isValidSignature is caught by validateContractSignature and surfaced as GS024.
+            await expect(testValidator.isValidSignature.staticCall(dataHash, signatures)).to.be.revertedWith("GS024");
+        });
+
+        it("should revert with GS024 if a non-owner contract's isValidSignature reverts", async () => {
+            const {
+                handler,
+                signers: [user1],
+            } = await setupTests();
+            const handlerAddress = await handler.getAddress();
+            const dataHash = ethers.keccak256("0xbaddad");
+
+            // Deploy a contract whose isValidSignature always reverts.
+            const revertingValidator = await revertingSignatureValidatorContract(user1);
+            const revertingValidatorAddress = await revertingValidator.getAddress();
+
+            // Create a Safe where user1 is the only owner, the reverting contract is NOT an owner.
+            const testSafe = await getSafe({ owners: [user1.address], threshold: 1, fallbackHandler: handlerAddress });
+            const testSafeAddress = await testSafe.getAddress();
+            const testValidator = await getCompatFallbackHandler(testSafeAddress);
+
+            // Build a contract signature pointing to the reverting non-owner.
+            // validateContractSignature is called before the owner-membership check (GS026), so the
+            // revert is caught and surfaced as GS024 rather than bubbling up to the caller.
+            const contractSig = buildContractSignature(revertingValidatorAddress, "0x");
+            const signatures = buildSignatureBytes([contractSig]);
+
+            await expect(testValidator.isValidSignature.staticCall(dataHash, signatures)).to.be.revertedWith("GS024");
         });
     });
 

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -83,6 +83,17 @@ export const badSimulatorContract = async (deployer: Signer) => {
     return deployContractFromSource(deployer, badSimulatorSource);
 };
 
+export const revertingSignatureValidatorSource = `
+contract Test {
+    function isValidSignature(bytes32, bytes memory) external pure returns (bytes4) {
+        revert("isValidSignature reverted");
+    }
+}`;
+
+export const revertingSignatureValidatorContract = async (deployer: Signer) => {
+    return deployContractFromSource(deployer, revertingSignatureValidatorSource);
+};
+
 /**
  * Retrieves the sender address from the contract runner.
  * It is useful when using methods like `hre.ethers.getContractAt` which automatically attach


### PR DESCRIPTION
---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

## Summary by Sourcery

Ensure contract signature validation does not propagate arbitrary revert data and instead standardizes failures as GS024, while tightening ERC-1271 return-data handling and improving fallback handler documentation.

New Features:
- Introduce SecuredSignatureValidator utility to safely validate ERC-1271 contract signatures via low-level calls.

Bug Fixes:
- Prevent bubbling up of revert data from contract owners during signature validation in Safe and CompatibilityFallbackHandler, reverting with GS024 instead.
- Correct the ERC-777 documentation in TokenCallbackHandler to reference the recipient interface and hash.
- Update the CLA link in the pull request template to the new safefoundation URL.

Enhancements:
- Document the Safe fallback handler call-forwarding model, security rationale for using CALL instead of DELEGATECALL, and implications of msg.sender rewriting.
- Add a reverting signature validator test contract and expand tests to cover GS024 behavior for reverting owner and non-owner contract signatures.

Documentation:
- Expand docs on fallback contract behavior, call forwarding via FallbackManager, and associated security considerations.

Tests:
- Add regression tests for Safe and CompatibilityFallbackHandler to assert GS024 on reverting isValidSignature calls, including owner and non-owner contract scenarios.

Chores:
- Update CHANGELOG for version 1.5.0 with details on secured contract signature validation and breaking changes in ERC-1271 return-data handling.